### PR TITLE
Create PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+<!-- Please follow this template when posting a new PR. -->
+### Branch 
+<!--
+Specify which branch this PR is based off of.
+-->
+
+### Trello Card
+
+<!--
+A summary of the trello card this PR represents.
+Include the link to the card.
+-->
+
+### Description
+
+<!--
+Description of your changes. More than a one-liner. We need to know why you did those changes.
+
+Some other questions that are good to answer here:
+  * Is there anything left to do as part of this card?
+  * Are there behaviour changes that should be explicitly described?
+  * Are these changes directly related to previous changes that were made?
+    * Should the previous PR be linked to (eg. fixing a bug implemented by a previous PR)?
+  * Is there any related functionality that was out of scope for this PR and might be overlooked/forgotten?
+-->
+
+### Tests
+
+<!--
+Description of the tests you ran.
+  * How to reproduce the bug
+  * How to determine that it has been fixed
+-->


### PR DESCRIPTION
### Branch 
master

### Trello Card
N/A

### Description
This is to enforce better PRs when they are being written. I pulled this from a repo I use at work and tailored it to our uses.

### Tests
N/A
