### PR TITLE
Split the info and announcements into separate tabs

### DIFF
--- a/cuHacking.xcodeproj/project.pbxproj
+++ b/cuHacking.xcodeproj/project.pbxproj
@@ -30,7 +30,7 @@
 		6B4BD46B22E7501100BF03E7 /* RiverBuildingOld.geojson in Resources */ = {isa = PBXBuildFile; fileRef = 6B4BD46A22E7501100BF03E7 /* RiverBuildingOld.geojson */; };
 		6B4BD46C22E7501100BF03E7 /* RiverBuildingOld.geojson in Resources */ = {isa = PBXBuildFile; fileRef = 6B4BD46A22E7501100BF03E7 /* RiverBuildingOld.geojson */; };
 		6B4BD46D22E7501100BF03E7 /* RiverBuildingOld.geojson in Resources */ = {isa = PBXBuildFile; fileRef = 6B4BD46A22E7501100BF03E7 /* RiverBuildingOld.geojson */; };
-		6B51E8C4239316CF00B4454C /* InformationDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B51E8C3239316CF00B4454C /* InformationDataSource.swift */; };
+		6B51E8C4239316CF00B4454C /* HomeDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B51E8C3239316CF00B4454C /* HomeDataSource.swift */; };
 		6B525B92231DED00005046FB /* CUButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B525B91231DED00005046FB /* CUButton.swift */; };
 		6B525B93231DED00005046FB /* CUButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B525B91231DED00005046FB /* CUButton.swift */; };
 		6B525B94231DED00005046FB /* CUButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B525B91231DED00005046FB /* CUButton.swift */; };
@@ -71,10 +71,10 @@
 		6B6D4F3C22D3D06000A9D4F9 /* UserDefaultsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6D4F3B22D3D06000A9D4F9 /* UserDefaultsAPI.swift */; };
 		6B6D4F3D22D3D06000A9D4F9 /* UserDefaultsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6D4F3B22D3D06000A9D4F9 /* UserDefaultsAPI.swift */; };
 		6B6D4F3E22D3D06000A9D4F9 /* UserDefaultsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6D4F3B22D3D06000A9D4F9 /* UserDefaultsAPI.swift */; };
-		6B6D4F4022D3D0E000A9D4F9 /* InformationRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6D4F3F22D3D0E000A9D4F9 /* InformationRepository.swift */; };
-		6B6D4F4122D3D0E000A9D4F9 /* InformationRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6D4F3F22D3D0E000A9D4F9 /* InformationRepository.swift */; };
-		6B6D4F4222D3D0E000A9D4F9 /* InformationRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6D4F3F22D3D0E000A9D4F9 /* InformationRepository.swift */; };
-		6B788BE7239D930300A8CF50 /* Information.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B788BE6239D930300A8CF50 /* Information.swift */; };
+		6B6D4F4022D3D0E000A9D4F9 /* HomeRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6D4F3F22D3D0E000A9D4F9 /* HomeRepository.swift */; };
+		6B6D4F4122D3D0E000A9D4F9 /* HomeRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6D4F3F22D3D0E000A9D4F9 /* HomeRepository.swift */; };
+		6B6D4F4222D3D0E000A9D4F9 /* HomeRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6D4F3F22D3D0E000A9D4F9 /* HomeRepository.swift */; };
+		6B788BE7239D930300A8CF50 /* Home.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B788BE6239D930300A8CF50 /* Home.swift */; };
 		6B788BE9239D932700A8CF50 /* InformationBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B788BE8239D932700A8CF50 /* InformationBuilder.swift */; };
 		6B788BEB239D933E00A8CF50 /* InformationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B788BEA239D933E00A8CF50 /* InformationView.swift */; };
 		6B788BED239D935800A8CF50 /* Schedule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B788BEC239D935800A8CF50 /* Schedule.swift */; };
@@ -87,6 +87,9 @@
 		6B87C35D22BFD66C00803F7C /* CUHackingUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B87C35C22BFD66C00803F7C /* CUHackingUITests.swift */; };
 		6B889678235CE96800D8DFED /* ImageLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B889677235CE96800D8DFED /* ImageLabelView.swift */; };
 		6B88967A235CEB7300D8DFED /* UIStackView+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B889679235CEB7300D8DFED /* UIStackView+Ext.swift */; };
+		6B8E075D23A53C5900C7702A /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8E075C23A53C5900C7702A /* HomeViewController.swift */; };
+		6B8E075F23A53E6000C7702A /* CUCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8E075E23A53E6000C7702A /* CUCollectionViewController.swift */; };
+		6B8E076123A571BF00C7702A /* HomeBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8E076023A571BF00C7702A /* HomeBuilder.swift */; };
 		6B91632A22EFB659009ADB0A /* Int+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B91632922EFB659009ADB0A /* Int+Ext.swift */; };
 		6B91632B22EFB659009ADB0A /* Int+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B91632922EFB659009ADB0A /* Int+Ext.swift */; };
 		6B91632C22EFB659009ADB0A /* Int+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B91632922EFB659009ADB0A /* Int+Ext.swift */; };
@@ -191,7 +194,7 @@
 		6B3E44E323973F88005719A9 /* cuHacking.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = cuHacking.entitlements; sourceTree = "<group>"; };
 		6B3E44E423973F88005719A9 /* NetworkExtension.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NetworkExtension.framework; path = System/Library/Frameworks/NetworkExtension.framework; sourceTree = SDKROOT; };
 		6B4BD46A22E7501100BF03E7 /* RiverBuildingOld.geojson */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = RiverBuildingOld.geojson; sourceTree = "<group>"; };
-		6B51E8C3239316CF00B4454C /* InformationDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InformationDataSource.swift; sourceTree = "<group>"; };
+		6B51E8C3239316CF00B4454C /* HomeDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeDataSource.swift; sourceTree = "<group>"; };
 		6B525B91231DED00005046FB /* CUButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CUButton.swift; sourceTree = "<group>"; };
 		6B525B95231DED08005046FB /* CUTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CUTextField.swift; sourceTree = "<group>"; };
 		6B52FBE3238A1C870096F81E /* InformationCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InformationCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -216,8 +219,8 @@
 		6B6A646C22F0DBCE006CAD6D /* CardState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardState.swift; sourceTree = "<group>"; };
 		6B6D4F3722D3D03600A9D4F9 /* DashboardAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardAPI.swift; sourceTree = "<group>"; };
 		6B6D4F3B22D3D06000A9D4F9 /* UserDefaultsAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsAPI.swift; sourceTree = "<group>"; };
-		6B6D4F3F22D3D0E000A9D4F9 /* InformationRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InformationRepository.swift; sourceTree = "<group>"; };
-		6B788BE6239D930300A8CF50 /* Information.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Information.swift; sourceTree = "<group>"; };
+		6B6D4F3F22D3D0E000A9D4F9 /* HomeRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeRepository.swift; sourceTree = "<group>"; };
+		6B788BE6239D930300A8CF50 /* Home.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Home.swift; sourceTree = "<group>"; };
 		6B788BE8239D932700A8CF50 /* InformationBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InformationBuilder.swift; sourceTree = "<group>"; };
 		6B788BEA239D933E00A8CF50 /* InformationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InformationView.swift; sourceTree = "<group>"; };
 		6B788BEC239D935800A8CF50 /* Schedule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Schedule.swift; sourceTree = "<group>"; };
@@ -236,6 +239,9 @@
 		6B87C35E22BFD66C00803F7C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6B889677235CE96800D8DFED /* ImageLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLabelView.swift; sourceTree = "<group>"; };
 		6B889679235CEB7300D8DFED /* UIStackView+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+Ext.swift"; sourceTree = "<group>"; };
+		6B8E075C23A53C5900C7702A /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
+		6B8E075E23A53E6000C7702A /* CUCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CUCollectionViewController.swift; sourceTree = "<group>"; };
+		6B8E076023A571BF00C7702A /* HomeBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeBuilder.swift; sourceTree = "<group>"; };
 		6B91632922EFB659009ADB0A /* Int+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+Ext.swift"; sourceTree = "<group>"; };
 		6B92F236236F834C00F0825B /* TitleImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleImageView.swift; sourceTree = "<group>"; };
 		6B9C99262375B248001B892C /* UserProfile.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = UserProfile.json; sourceTree = "<group>"; };
@@ -298,28 +304,9 @@
 		6B29893022C5A7C900B1550C /* Information */ = {
 			isa = PBXGroup;
 			children = (
-				6B29893122C5A7F800B1550C /* Data */,
-				6B29893222C5A80300B1550C /* Domain */,
 				6B29893322C5A81B00B1550C /* UI */,
 			);
 			path = Information;
-			sourceTree = "<group>";
-		};
-		6B29893122C5A7F800B1550C /* Data */ = {
-			isa = PBXGroup;
-			children = (
-				6B6D4F3F22D3D0E000A9D4F9 /* InformationRepository.swift */,
-				6B51E8C3239316CF00B4454C /* InformationDataSource.swift */,
-			);
-			path = Data;
-			sourceTree = "<group>";
-		};
-		6B29893222C5A80300B1550C /* Domain */ = {
-			isa = PBXGroup;
-			children = (
-				6B788BE6239D930300A8CF50 /* Information.swift */,
-			);
-			path = Domain;
 			sourceTree = "<group>";
 		};
 		6B29893322C5A81B00B1550C /* UI */ = {
@@ -456,6 +443,7 @@
 				6B92F236236F834C00F0825B /* TitleImageView.swift */,
 				6B52FBE3238A1C870096F81E /* InformationCollectionViewCell.swift */,
 				6B52FBE5238A32890096F81E /* TitleSubtitleCollectionViewCell.swift */,
+				6B8E075E23A53E6000C7702A /* CUCollectionViewController.swift */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -561,6 +549,7 @@
 			children = (
 				6B3E44E323973F88005719A9 /* cuHacking.entitlements */,
 				6B659F27235BE32700EBAF7E /* Resources */,
+				6B8E075823A53BC900C7702A /* Home */,
 				6B29893022C5A7C900B1550C /* Information */,
 				6B29893A22C5A92D00B1550C /* QRScanner */,
 				6B29893922C5A90A00B1550C /* Profile */,
@@ -596,6 +585,42 @@
 				6B87C35E22BFD66C00803F7C /* Info.plist */,
 			);
 			path = cuHackingUITests;
+			sourceTree = "<group>";
+		};
+		6B8E075823A53BC900C7702A /* Home */ = {
+			isa = PBXGroup;
+			children = (
+				6B8E075923A53BE300C7702A /* Data */,
+				6B8E075A23A53BE900C7702A /* Domain */,
+				6B8E075B23A53BEE00C7702A /* UI */,
+			);
+			path = Home;
+			sourceTree = "<group>";
+		};
+		6B8E075923A53BE300C7702A /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				6B6D4F3F22D3D0E000A9D4F9 /* HomeRepository.swift */,
+				6B51E8C3239316CF00B4454C /* HomeDataSource.swift */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
+		6B8E075A23A53BE900C7702A /* Domain */ = {
+			isa = PBXGroup;
+			children = (
+				6B788BE6239D930300A8CF50 /* Home.swift */,
+			);
+			path = Domain;
+			sourceTree = "<group>";
+		};
+		6B8E075B23A53BEE00C7702A /* UI */ = {
+			isa = PBXGroup;
+			children = (
+				6B8E075C23A53C5900C7702A /* HomeViewController.swift */,
+				6B8E076023A571BF00C7702A /* HomeBuilder.swift */,
+			);
+			path = UI;
 			sourceTree = "<group>";
 		};
 		6B9C99232375B159001B892C /* DummyData */ = {
@@ -949,7 +974,7 @@
 				6B87C33A22BFD66B00803F7C /* AppDelegate.swift in Sources */,
 				6B92F237236F834D00F0825B /* TitleImageView.swift in Sources */,
 				6BFFA12A230E6A5D00DD92C7 /* InfoCell.swift in Sources */,
-				6B788BE7239D930300A8CF50 /* Information.swift in Sources */,
+				6B788BE7239D930300A8CF50 /* Home.swift in Sources */,
 				6B525B92231DED00005046FB /* CUButton.swift in Sources */,
 				6B87C34222BFD66B00803F7C /* cuHacking.xcdatamodeld in Sources */,
 				6BC82A8E22E11ABB006E2CFC /* MapDataSource.swift in Sources */,
@@ -960,7 +985,8 @@
 				6B6A646922F0DB12006CAD6D /* CardViewController.swift in Sources */,
 				6B9C99292375B284001B892C /* UserProfile.swift in Sources */,
 				6BF9291922C6FB1900007616 /* SettingsViewController.swift in Sources */,
-				6B51E8C4239316CF00B4454C /* InformationDataSource.swift in Sources */,
+				6B8E075D23A53C5900C7702A /* HomeViewController.swift in Sources */,
+				6B51E8C4239316CF00B4454C /* HomeDataSource.swift in Sources */,
 				6B13288C2395E70700421EFB /* ScheduleRepository.swift in Sources */,
 				6B26322C22C6468B0034CA72 /* ProfileViewController.swift in Sources */,
 				6BF9291522C6F82E00007616 /* UINavigationController+Ext.swift in Sources */,
@@ -983,12 +1009,14 @@
 				6BEB3308231DDD6000F79CEE /* SignInViewController.swift in Sources */,
 				6B6D4F3C22D3D06000A9D4F9 /* UserDefaultsAPI.swift in Sources */,
 				6B525B96231DED08005046FB /* CUTextField.swift in Sources */,
-				6B6D4F4022D3D0E000A9D4F9 /* InformationRepository.swift in Sources */,
+				6B6D4F4022D3D0E000A9D4F9 /* HomeRepository.swift in Sources */,
 				6B788BEF239D936000A8CF50 /* ScheduleBuilder.swift in Sources */,
 				6B67E9EF235D531500288F8D /* ProfileVC.swift in Sources */,
+				6B8E076123A571BF00C7702A /* HomeBuilder.swift in Sources */,
 				6B29894522C5C5A300B1550C /* InformationViewController.swift in Sources */,
 				6B788BEB239D933E00A8CF50 /* InformationView.swift in Sources */,
 				6BA16484231DCEE600EB186D /* ProfileDataSource.swift in Sources */,
+				6B8E075F23A53E6000C7702A /* CUCollectionViewController.swift in Sources */,
 				6B91632A22EFB659009ADB0A /* Int+Ext.swift in Sources */,
 				6B13288E2395E76D00421EFB /* ScheduleDataSource.swift in Sources */,
 				6B88967A235CEB7300D8DFED /* UIStackView+Ext.swift in Sources */,
@@ -1011,7 +1039,7 @@
 				6B91632B22EFB659009ADB0A /* Int+Ext.swift in Sources */,
 				6BC82A7F22E0ACB8006E2CFC /* MapViewModel.swift in Sources */,
 				6BE10D3422F22A6700280D21 /* String+Ext.swift in Sources */,
-				6B6D4F4122D3D0E000A9D4F9 /* InformationRepository.swift in Sources */,
+				6B6D4F4122D3D0E000A9D4F9 /* HomeRepository.swift in Sources */,
 				6BEB3309231DDD6000F79CEE /* SignInViewController.swift in Sources */,
 				6B37336E22E3D1BA00F648A6 /* Level.swift in Sources */,
 				6B6A646A22F0DB12006CAD6D /* CardViewController.swift in Sources */,
@@ -1039,7 +1067,7 @@
 				6B91632C22EFB659009ADB0A /* Int+Ext.swift in Sources */,
 				6BC82A8022E0ACB8006E2CFC /* MapViewModel.swift in Sources */,
 				6BE10D3522F22A6700280D21 /* String+Ext.swift in Sources */,
-				6B6D4F4222D3D0E000A9D4F9 /* InformationRepository.swift in Sources */,
+				6B6D4F4222D3D0E000A9D4F9 /* HomeRepository.swift in Sources */,
 				6BEB330A231DDD6000F79CEE /* SignInViewController.swift in Sources */,
 				6B37336F22E3D1BA00F648A6 /* Level.swift in Sources */,
 				6B6A646B22F0DB12006CAD6D /* CardViewController.swift in Sources */,

--- a/cuHacking/Home/Data/HomeDataSource.swift
+++ b/cuHacking/Home/Data/HomeDataSource.swift
@@ -11,12 +11,12 @@ enum MagnentonError: Error {
     case fetch(message: String)
     case data(message: String)
 }
-class InformationDataSource: InformationRepository {
+class HomeDataSource: HomeRepository {
     private static let baseURL = "https://cuhacking.com/api-dev"
     private static let okResponse = 200
 
     func getUpdates(completionHandler: @escaping (MagnetonAPIObject.Updates?, Error?) -> Void) {
-        let baseURL = InformationDataSource.baseURL + "/updates"
+        let baseURL = HomeDataSource.baseURL + "/updates"
         guard let url = URL(string: baseURL) else { return }
 
         URLSession.shared.dataTask(with: url) { (data, response, error) in
@@ -25,7 +25,7 @@ class InformationDataSource: InformationRepository {
                 return
             }
             let response = response as? HTTPURLResponse
-            if response?.statusCode != InformationDataSource.okResponse {
+            if response?.statusCode != HomeDataSource.okResponse {
                 let error = MagnentonError.fetch(message: "Failed to fetch updates. HTTP Response: \(response?.statusCode ?? -1)")
                 completionHandler(nil, error)
                 return

--- a/cuHacking/Home/Data/HomeRepository.swift
+++ b/cuHacking/Home/Data/HomeRepository.swift
@@ -7,6 +7,6 @@
 //
 
 import Foundation
-protocol InformationRepository {
+protocol HomeRepository {
     func getUpdates(completionHandler: @escaping (MagnetonAPIObject.Updates?, Error?) -> Void)   	
 }

--- a/cuHacking/Home/Domain/Home.swift
+++ b/cuHacking/Home/Domain/Home.swift
@@ -13,7 +13,7 @@ extension MagnetonAPIObject {
         let updates: [String: Update]
         public var relevantUpdates: [Update] {
             let currentDate = Int64(Date().timeIntervalSince1970) * 1000
-            let keys = Array(updates.keys).sorted(by: <).filter { (key) -> Bool in
+            let keys = Array(updates.keys).sorted(by: >).filter { (key) -> Bool in
                 if let update = updates[key] {
                     return currentDate >= update.deliveryTime
                 } else {

--- a/cuHacking/Home/UI/HomeBuilder.swift
+++ b/cuHacking/Home/UI/HomeBuilder.swift
@@ -1,0 +1,50 @@
+//
+//  HomeBuilder.swift
+//  cuHacking
+//
+//  Created by Santos on 2019-12-14.
+//  Copyright © 2019 cuHacking. All rights reserved.
+//
+
+import UIKit
+enum HomeBuilder {
+    enum Cells: String {
+        case headerCell = "HeaderCell"
+        case onboardingCell = "OnboardingCell"
+        case updateCell = "UpdateCell"
+    }
+
+    enum Header {
+        static func headerCell(collectionView: UICollectionView, indexPath: IndexPath) -> HeaderCell {
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Cells.headerCell.rawValue, for: indexPath) as? HeaderCell else {
+                fatalError("Headercell was not found.")
+            }
+            cell.titleLabel.text = Strings.Information.HeaderCell.title
+            return cell
+        }
+        static func onbaordingCell(collectionView: UICollectionView, indexPath: IndexPath) -> OnboardingCell {
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Cells.onboardingCell.rawValue, for: indexPath) as? OnboardingCell else {
+                fatalError("Onboarding cell was not found")
+            }
+            cell.informationView.backgroundColor = Asset.Colors.surface.color
+            cell.informationView.dropShadow()
+            cell.informationView.titleLabel.textColor = Asset.Colors.primary.color
+            //cell.informationView.isCentered = true
+            cell.informationView.update(title: "Welcome to Local Hack Day!", information: "Before you begin your day, please make sure you are registered.")
+            return cell
+        }
+    }
+
+    enum Announcements {
+        static func updateCell(updates: [MagnetonAPIObject.Update] ,collectionView: UICollectionView, indexPath: IndexPath) -> UpdateCell {
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Cells.updateCell.rawValue, for: indexPath) as? UpdateCell else {
+                fatalError("Update cell wsa not found.")
+            }
+            let update = updates[indexPath.row]
+            cell.informationView.backgroundColor = Asset.Colors.surface.color
+            cell.informationView.dropShadow()
+            cell.informationView.update(title: update.title, information: update.description, buttonTitle: nil)
+            return cell
+        }
+    }
+}

--- a/cuHacking/Home/UI/HomeViewController.swift
+++ b/cuHacking/Home/UI/HomeViewController.swift
@@ -1,0 +1,147 @@
+//
+//  HomeViewController.swift
+//  cuHacking
+//
+//  Created by Santos on 2019-12-14.
+//  Copyright © 2019 cuHacking. All rights reserved.
+//
+
+import UIKit
+
+typealias HeaderCell = TitleSubtitleCollectionViewCell
+typealias OnboardingCell = InformationCollectionViewCell
+typealias UpdateCell = InformationCollectionViewCell
+
+class HomeViewController: CUCollectionViewController {
+    private var updates: [MagnetonAPIObject.Update]?
+    private var dataSource: HomeRepository
+
+    init(dataSource: HomeRepository = HomeDataSource()) {
+        self.dataSource = dataSource
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupNavigationController()
+        loadUpdates()
+    }
+    
+    override func setupCollectionView() {
+        super.setupCollectionView()
+        collectionView.dataSource = self
+    }
+    
+    override func registerCells() {
+        super.registerCells()
+        collectionView.register(OnboardingCell.self, forCellWithReuseIdentifier: HomeBuilder.Cells.onboardingCell.rawValue)
+        collectionView.register(HeaderCell.self, forCellWithReuseIdentifier: HomeBuilder.Cells.headerCell.rawValue)
+        collectionView.register(UpdateCell.self, forCellWithReuseIdentifier: HomeBuilder.Cells.updateCell.rawValue)
+    }
+
+    private func setupNavigationController() {
+        self.navigationController?.navigationBar.topItem?.title = "cuHacking"
+        self.navigationController?.navigationBar.tintColor = Asset.Colors.primaryText.color
+        //Adding profile icon button to navigation bar
+        let settingsIconBar = UIBarButtonItem(image: Asset.Images.settingsIcon.image, style: .plain, target: self, action: #selector(showSettings))
+        self.navigationItem.rightBarButtonItem = settingsIconBar
+        //Adding QR Scan icon to button navigation bar IF user is admin
+        //let qrBarItem = UIBarButtonItem(image: Asset.Images.qrIcon.image, style: .plain, target: self, action: #selector(showQRScanner))
+        //self.navigationItem.leftBarButtonItem = qrBarItem
+    }
+
+    private func loadUpdates() {
+        HomeDataSource().getUpdates { [weak self] (updates, error) in
+            DispatchQueue.main.async {
+               if self?.refreshController.isRefreshing == true {
+                   self?.refreshController.endRefreshing()
+               }
+            }
+            if error != nil {
+                print(error)
+                return
+            }
+            guard let updates = updates else {
+                print("Failed to get updates")
+                return
+            }
+            self?.updates = updates.relevantUpdates
+            DispatchQueue.main.async {
+                self?.collectionView.reloadData()
+            }
+        }
+    }
+
+    @objc func showSettings() {
+        let settingsViewController = SettingsViewController()
+//        let profileViewController = SignInViewController(nibName: "SignInViewController", bundle: nil)
+        self.navigationController?.pushViewController(settingsViewController, animated: false)
+    }
+
+    @objc func showQRScanner() {
+        let qrScannerViewController = QRScannerViewController()
+        navigationController?.pushViewController(qrScannerViewController, animated: false)
+    }
+}
+
+extension HomeViewController: UICollectionViewDataSource {
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        return 2
+    }
+
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        switch section {
+        case 0:
+            return 2
+        case 1:
+            return updates?.count ?? 0
+        default:
+            fatalError("Too many sections")
+        }
+    }
+
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        switch indexPath.section {
+        case 0: // Header Section
+            switch indexPath.row {
+            case 0:
+                return HomeBuilder.Header.headerCell(collectionView: collectionView, indexPath: indexPath)
+            case 1:
+                return HomeBuilder.Header.onbaordingCell(collectionView: collectionView, indexPath: indexPath)
+            default:
+                fatalError("Row out of range")
+            }
+        case 1: //Info section
+            guard let updates = updates else {
+                fatalError("Asking for updates when none exist.")
+            }
+            return HomeBuilder.Announcements.updateCell(updates: updates, collectionView: collectionView, indexPath: indexPath)
+        default:
+            fatalError("Section out of range")
+        }
+    }
+
+    func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+        let headerKind = UICollectionView.elementKindSectionHeader
+
+        if kind == headerKind,
+            let titleImageView = collectionView.dequeueReusableSupplementaryView(ofKind: headerKind, withReuseIdentifier: "TitleImageView", for: indexPath) as? TitleImageView {
+            switch indexPath.section {
+            case 1:
+                titleImageView.update(title: "Announcements", image: nil)
+                return titleImageView
+            default:
+                break
+            }
+        }
+        guard let titleImageView = collectionView.dequeueReusableSupplementaryView(ofKind: headerKind, withReuseIdentifier: "TitleImageView", for: indexPath) as? TitleImageView else {
+            fatalError("Title image view not found")
+        }
+        titleImageView.update(title: nil, image: nil)
+        return titleImageView
+    }
+}

--- a/cuHacking/Information/UI/InformationBuilder.swift
+++ b/cuHacking/Information/UI/InformationBuilder.swift
@@ -7,33 +7,11 @@
 //
 
 import UIKit
-enum InformationViewBuilder {
+enum InformationBuilder {
     enum Cells: String {
-        case headerCell = "HeaderCell"
         case informationCell = "InfoCell"
-        case onboardingCell = "OnboardingCell"
-        case updateCell = "UpdateCell"
     }
-    enum Header {
-        static func headerCell(collectionView: UICollectionView, indexPath: IndexPath) -> HeaderCell {
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Cells.headerCell.rawValue, for: indexPath) as? HeaderCell else {
-                fatalError("Headercell was not found.")
-            }
-            cell.titleLabel.text = Strings.Information.HeaderCell.title
-            return cell
-        }
-        static func onbaordingCell(collectionView: UICollectionView, indexPath: IndexPath) -> OnboardingCell {
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Cells.onboardingCell.rawValue, for: indexPath) as? OnboardingCell else {
-                fatalError("Onboarding cell was not found")
-            }
-            cell.informationView.backgroundColor = Asset.Colors.surface.color
-            cell.informationView.dropShadow()
-            cell.informationView.titleLabel.textColor = Asset.Colors.primary.color
-            //cell.informationView.isCentered = true
-            cell.informationView.update(title: "Welcome to Local Hack Day!", information: "Before you begin your day, please make sure you are registered.")
-            return cell
-        }
-    }
+
     enum Info {
         static func infoCell(collectionView: UICollectionView, indexPath: IndexPath) -> InformationCell {
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Cells.informationCell.rawValue, for: indexPath) as? InformationCell else {
@@ -43,18 +21,6 @@ enum InformationViewBuilder {
             cell.informationView.titleLabel.textColor = .black
             cell.informationView.informationTextView.textColor = .black
             cell.informationView.update(title: "Wifi Info", information: wifiInfo, buttonTitle: nil)
-            return cell
-        }
-    }
-    enum Announcements {
-        static func updateCell(updates: [MagnetonAPIObject.Update] ,collectionView: UICollectionView, indexPath: IndexPath) -> UpdateCell {
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Cells.updateCell.rawValue, for: indexPath) as? UpdateCell else {
-                fatalError("Update cell wsa not found.")
-            }
-            let update = updates[indexPath.row]
-            cell.informationView.backgroundColor = Asset.Colors.surface.color
-            cell.informationView.dropShadow()
-            cell.informationView.update(title: update.title, information: update.description, buttonTitle: nil)
             return cell
         }
     }

--- a/cuHacking/Information/UI/InformationViewController.swift
+++ b/cuHacking/Information/UI/InformationViewController.swift
@@ -11,108 +11,20 @@ import Firebase
 import Crashlytics
 import NetworkExtension
 
-typealias HeaderCell = TitleSubtitleCollectionViewCell
-typealias OnboardingCell = InformationCollectionViewCell
 typealias InformationCell = InformationCollectionViewCell
-typealias UpdateCell = InformationCollectionViewCell
 
-class InformationViewController: UIViewController {
-    private var collectionViewFlowLayout: UICollectionViewFlowLayout {
-        let flowLayout = UICollectionViewFlowLayout()
-        flowLayout.headerReferenceSize = CGSize(width: view.bounds.width, height: 50)
-        flowLayout.estimatedItemSize = CGSize(width: view.bounds.width, height: 10)
-        return flowLayout
+class InformationViewController: CUCollectionViewController {
+
+    override func registerCells() {
+        super.registerCells()
+        collectionView.register(InformationCell.self, forCellWithReuseIdentifier: InformationBuilder.Cells.informationCell.rawValue)
     }
 
-    var collectionView: UICollectionView!
-    private var updates: [MagnetonAPIObject.Update]?
-    private var dataSource: InformationRepository
-    private let refreshController = UIRefreshControl()
-
-    init(dataSource: InformationRepository = InformationDataSource()) {
-        self.dataSource = dataSource
-        super.init(nibName: nil, bundle: nil)
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        setupCollectionView()
-        setupNavigationController()
-        loadUpdates()
-    }
-
-    private func registerCells() {
-        collectionView.register(OnboardingCell.self, forCellWithReuseIdentifier: InformationViewBuilder.Cells.onboardingCell.rawValue)
-        collectionView.register(HeaderCell.self, forCellWithReuseIdentifier: InformationViewBuilder.Cells.headerCell.rawValue)
-        collectionView.register(InformationCell.self, forCellWithReuseIdentifier: InformationViewBuilder.Cells.informationCell.rawValue)
-        collectionView.register(UpdateCell.self, forCellWithReuseIdentifier: InformationViewBuilder.Cells.updateCell.rawValue)
-        collectionView.register(TitleImageView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: "TitleImageView")
-    }
-
-    private func createCrashButton() {
-        let crashButton = UIButton(frame: CGRect(x: 20, y: 100, width: 100, height: 50))
-        crashButton.addTarget(self, action: #selector(crashApp), for: .touchUpInside)
-        crashButton.setTitle("Crash!", for: .normal)
-        crashButton.backgroundColor = .red
-        crashButton.layer.cornerRadius = 4
-        self.view.addSubview(crashButton)
-    }
-
-    private func setupCollectionView() {
-        collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewFlowLayout)
-        collectionView.backgroundColor = Asset.Colors.background.color
-        registerCells()
+    override func setupCollectionView() {
+        super.setupCollectionView()
         collectionView.dataSource = self
-        collectionView.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(collectionView)
-        collectionView.fillSuperview()
-        
-        collectionView.alwaysBounceVertical = true
-        refreshController.addTarget(self, action: #selector(refreshData), for: .valueChanged)
-        collectionView.addSubview(refreshController)
     }
 
-    private func loadUpdates() {
-        InformationDataSource().getUpdates { [weak self] (updates, error) in
-            DispatchQueue.main.async {
-               if self?.refreshController.isRefreshing == true {
-                   self?.refreshController.endRefreshing()
-               }
-            }
-            if error != nil {
-                print(error)
-                return
-            }
-            guard let updates = updates else {
-                print("Failed to get updates")
-                return
-            }
-            self?.updates = updates.relevantUpdates
-            DispatchQueue.main.async {
-                self?.collectionView.reloadData()
-            }
-        }
-    }
-
-    @objc func crashApp() {
-        Crashlytics.sharedInstance().crash()
-    }
-
-    @objc func showSettings() {
-        let settingsViewController = SettingsViewController()
-//        let profileViewController = SignInViewController(nibName: "SignInViewController", bundle: nil)
-        self.navigationController?.pushViewController(settingsViewController, animated: false)
-    }
-
-    @objc func showQRScanner() {
-        let qrScannerViewController = QRScannerViewController()
-        navigationController?.pushViewController(qrScannerViewController, animated: false)
-    }
-    
 //    @objc func connectToWifi() {
 //        let hotSpotConfig = NEHotspotConfiguration(ssid: "HOME", passphrase: "cuhacking", isWEP: false)
 //        NEHotspotConfigurationManager.shared.apply(hotSpotConfig) { (error) in
@@ -126,82 +38,25 @@ class InformationViewController: UIViewController {
 }
 
 extension InformationViewController: UICollectionViewDataSource {
-    func numberOfSections(in collectionView: UICollectionView) -> Int {
-        return 3
-    }
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        switch section {
-        case 0:
-            return 2
-        case 1:
-            return 1
-        case 2:
-            return updates?.count ?? 0
-        default:
-            fatalError("Too many sections")
-        }
+        return 1
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        switch indexPath.section {
-        case 0: // Header Section
-            switch indexPath.row {
-            case 0:
-                return InformationViewBuilder.Header.headerCell(collectionView: collectionView, indexPath: indexPath)
-            case 1:
-                return InformationViewBuilder.Header.onbaordingCell(collectionView: collectionView, indexPath: indexPath)
-            default:
-                fatalError("Row out of range")
-            }
-        case 1: //Info section
-            return InformationViewBuilder.Info.infoCell(collectionView: collectionView, indexPath: indexPath)
-        case 2:
-            guard let updates = updates else {
-                fatalError("No udpates")
-            }
-            return InformationViewBuilder.Announcements.updateCell(updates: updates, collectionView: collectionView, indexPath: indexPath)
-        default:
-            fatalError("Section out of range")
-        }
+        return InformationBuilder.Info.infoCell(collectionView: collectionView, indexPath: indexPath)
     }
 
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
         let headerKind = UICollectionView.elementKindSectionHeader
 
-        if kind == headerKind,
-            let titleImageView = collectionView.dequeueReusableSupplementaryView(ofKind: headerKind, withReuseIdentifier: "TitleImageView", for: indexPath) as? TitleImageView {
-            switch indexPath.section {
-            case 1:
-                titleImageView.update(title: "Info", image: nil)
-                return titleImageView
-            case 2:
-                titleImageView.update(title: "Announcements", image: nil)
-                return titleImageView
-            default:
-                break
-            }
-        }
         guard let titleImageView = collectionView.dequeueReusableSupplementaryView(ofKind: headerKind, withReuseIdentifier: "TitleImageView", for: indexPath) as? TitleImageView else {
             fatalError("Title image view not found")
         }
-        titleImageView.update(title: nil, image: nil)
-        return titleImageView
-    }
-}
 
-extension InformationViewController {
-    @objc func refreshData() {
-        refreshController.beginRefreshing()
-        loadUpdates()
-    }
-    private func setupNavigationController() {
-        self.navigationController?.navigationBar.topItem?.title = "cuHacking"
-        self.navigationController?.navigationBar.tintColor = Asset.Colors.primaryText.color
-        //Adding profile icon button to navigation bar
-        let settingsIconBar = UIBarButtonItem(image: Asset.Images.settingsIcon.image, style: .plain, target: self, action: #selector(showSettings))
-        self.navigationItem.rightBarButtonItem = settingsIconBar
-        //Adding QR Scan icon to button navigation bar IF user is admin
-        //let qrBarItem = UIBarButtonItem(image: Asset.Images.qrIcon.image, style: .plain, target: self, action: #selector(showQRScanner))
-        //self.navigationItem.leftBarButtonItem = qrBarItem
+        if kind == headerKind {
+            titleImageView.update(title: "Information", image: nil)
+        } else { titleImageView.update(title: nil, image: nil) }
+
+        return titleImageView
     }
 }

--- a/cuHacking/Schedule/UI/ScheduleViewController.swift
+++ b/cuHacking/Schedule/UI/ScheduleViewController.swift
@@ -8,18 +8,9 @@
 
 import UIKit
 
-class ScheduleViewController: UIViewController {
-    private var collectionViewFlowLayout: UICollectionViewFlowLayout {
-        let flowLayout = UICollectionViewFlowLayout()
-        flowLayout.headerReferenceSize = CGSize(width: view.bounds.width, height: 50)
-        flowLayout.estimatedItemSize = CGSize(width: view.bounds.width, height: 10)
-        return flowLayout
-    }
-
-    var collectionView: UICollectionView!
+class ScheduleViewController: CUCollectionViewController {
     var events: [MagnetonAPIObject.Event]?
     private let dataSource: ScheduleRepository
-    private let refreshController = UIRefreshControl()
 
     init(dataSource: ScheduleRepository = ScheduleDataSource()) {
         self.dataSource = dataSource
@@ -32,27 +23,16 @@ class ScheduleViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor =  Asset.Colors.background.color
-        setupCollectionView()
         registerCells()
         loadEvents()
     }
 
-    private func setupCollectionView() {
-        collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewFlowLayout)
-        collectionView.backgroundColor = Asset.Colors.background.color
-        registerCells()
+    override func setupCollectionView() {
+        super.setupCollectionView()
         collectionView.dataSource = self
-        collectionView.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(collectionView)
-        collectionView.fillSuperview()
-        
-        collectionView.alwaysBounceVertical = true
-        refreshController.addTarget(self, action: #selector(refreshData), for: .valueChanged)
-        collectionView.addSubview(refreshController)
     }
 
-    private func registerCells() {
+    override func registerCells() {
         collectionView.register(EventCollectionViewCell.self, forCellWithReuseIdentifier: ScheduleViewBuilder.Cells.eventCell.rawValue)
          collectionView.register(TitleImageView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: "TitleImageView")
     }
@@ -79,7 +59,7 @@ class ScheduleViewController: UIViewController {
         }
     }
     
-    @objc private func refreshData() {
+    override func refreshData() {
         refreshController.beginRefreshing()
         loadEvents()
     }

--- a/cuHacking/UI/CUCollectionViewController.swift
+++ b/cuHacking/UI/CUCollectionViewController.swift
@@ -1,0 +1,45 @@
+//
+//  CUCollectionViewController.swift
+//  cuHacking
+//
+//  Created by Santos on 2019-12-14.
+//  Copyright © 2019 cuHacking. All rights reserved.
+//
+
+import UIKit
+class CUCollectionViewController: UIViewController {
+    private var collectionViewFlowLayout: UICollectionViewFlowLayout {
+        let flowLayout = UICollectionViewFlowLayout()
+        flowLayout.headerReferenceSize = CGSize(width: view.bounds.width, height: 50)
+        flowLayout.estimatedItemSize = CGSize(width: view.bounds.width, height: 10)
+        return flowLayout
+    }
+
+    var collectionView: UICollectionView!
+    let refreshController = UIRefreshControl()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor =  Asset.Colors.background.color
+        setupCollectionView()
+    }
+
+    func registerCells() {
+        collectionView.register(TitleImageView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: "TitleImageView")
+    }
+
+    @objc func refreshData() {}
+
+    func setupCollectionView() {
+        collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewFlowLayout)
+        collectionView.backgroundColor = Asset.Colors.background.color
+        registerCells()
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(collectionView)
+        collectionView.fillSuperview()
+
+        collectionView.alwaysBounceVertical = true
+        refreshController.addTarget(self, action: #selector(refreshData), for: .valueChanged)
+        collectionView.addSubview(refreshController)
+    }
+}

--- a/cuHacking/UI/CUTabBarController.swift
+++ b/cuHacking/UI/CUTabBarController.swift
@@ -11,23 +11,29 @@
 import UIKit
 class CUTabBarController: UITabBarController {
     override func viewDidLoad() {
-        //First tab - Information VC
-        let informationViewController = InformationViewController()
-        let navigationController = UINavigationController(rootViewController: informationViewController)
+        // First tab - Home
+        let homeViewController = HomeViewController()
+        let navigationController = UINavigationController(rootViewController: homeViewController)
         navigationController.navigationBar.tintColor =  Asset.Colors.gray.color
-        navigationController.tabBarItem = UITabBarItem(title: "Info", image: Asset.Images.info.image, tag: 0)
+        navigationController.tabBarItem = UITabBarItem(title: "Home", image: Asset.Images.homeIcon.image, tag: 0)
 
-        //Second tab - Schedule VC
+        // Second tab - Information VC
+        let informationViewController = InformationViewController()
+        informationViewController.tabBarItem = UITabBarItem(title: "Info", image: Asset.Images.info.image, tag: 1)
+                
+        //Third tab - Schedule VC
         let scheduleViewController = ScheduleViewController()
-        scheduleViewController.tabBarItem = UITabBarItem(title: "Schedule", image: Asset.Images.scheduleIcon.image, tag: 1)
+        scheduleViewController.tabBarItem = UITabBarItem(title: "Schedule", image: Asset.Images.scheduleIcon.image, tag: 2)
 
-        //Third tab - Map vc
-//        let viewModel = MapViewModel(mapDataSource: MapDataSource())
-//        let mapViewController = MapViewController(viewModel: viewModel!)
-//        mapViewController.tabBarItem = UITabBarItem(title: "Map", image: Asset.Images.mapIcon.image, tag: 2)
+//        Fourth tab - Map vc
+        let viewModel = MapViewModel(mapDataSource: MapDataSource())
+        let mapViewController = MapViewController(viewModel: viewModel!)
+        mapViewController.tabBarItem = UITabBarItem(title: "Map", image: Asset.Images.mapIcon.image, tag: 3)
 
         //Setting view controllers
-        viewControllers = [navigationController, scheduleViewController]
+        viewControllers = [navigationController,
+                           informationViewController,
+                           scheduleViewController]
         tabBar.tintColor =  Asset.Colors.purple.color
         tabBar.unselectedItemTintColor =  Asset.Colors.gray.color
     }


### PR DESCRIPTION
### Branch 
`splitInfoAndAnnouncements`

### Trello Card

[Card](https://trello.com/c/cnyRldMa/224-split-announcements-and-info-into-separate-pages)

Splitting the information and announcements card into 2 separate tabs in the apps because having all that information on one screen will lead to clutter. 

### Description
This PR separates the information and announcements into 2 separate tabs. The announcements tab has now be named `Home` and is the default tab in the app, while the Info tab is the 2nd tab in the app and as of right now contains wifi information. 

I still need to implement the countdown logic that we want to display on the Home tab. 

Before | After
------------ | -------------
<img src="https://user-images.githubusercontent.com/40777393/70853885-36ab5000-1e82-11ea-9e46-c9c907baf1f2.PNG" height="400" /> | <img src="https://user-images.githubusercontent.com/40777393/70853889-4165e500-1e82-11ea-9036-0dacb83049be.png" height="400" />